### PR TITLE
use a redirect to a CORS workaround if the GET does not succeed

### DIFF
--- a/js/survey_participant_ip.js
+++ b/js/survey_participant_ip.js
@@ -1,15 +1,27 @@
 $(function() {
-    $.get('https://api.ipify.org/?format=json', function(data) {
-        if (typeof data.ip === 'undefined' || !data.ip) {
-            return;
-        }
+    var url = 'https://api.ipify.org/?format=json';
+    function storeIP(url) {
+        var bool = false;
+        $.get(url
+              ,function(data) {
+                  if (typeof data.ip === 'undefined' || !data.ip) {
+                      return;
+                  }
 
-        SurveyParticipantIP.fields.forEach(function(name) {
-            $field = $('[name="' + name + '"]');
+                  SurveyParticipantIP.fields.forEach(function(name) {
+                      $field = $('[name="' + name + '"]');
 
-            if ($field.length > 0) {
-                $field.val(data.ip);
-            }
-        });
-    }, 'json');
+                      if ($field.length > 0) {
+                          $field.val(data.ip);
+                      }
+                  });
+              },
+              function(success) { bool = success; },
+              'json');
+        return bool;
+    }
+
+    if (!storeIP(url)) {
+        storeIP(`https://cors-anywhere.herokuapp.com/${url}`);
+    }
 });


### PR DESCRIPTION
If the get request to the ipify api fails, retry via [cors-anywhere](https://github.com/Rob--W/cors-anywhere) proxy.

This was able to capture my IP while using the uBlock Origin browser extension, which previously prevented the GET request from being performed (at least on my macbook).

Not tested on production server.